### PR TITLE
SG Heath Spell fix

### DIFF
--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -1989,7 +1989,7 @@
       <source>SG</source>
       <category>Health</category>
       <damage>0</damage>
-      <descriptor>Negative</descriptor>
+      <descriptor>Essence</descriptor>
       <duration>P</duration>
       <dv>F-2</dv>
       <range>T</range>
@@ -2002,7 +2002,7 @@
       <source>SG</source>
       <category>Health</category>
       <damage>0</damage>
-      <descriptor>Negative</descriptor>
+      <descriptor>Essence</descriptor>
       <duration>S</duration>
       <dv>F-3</dv>
       <range>T</range>
@@ -2054,7 +2054,7 @@
       <source>SG</source>
       <category>Health</category>
       <damage>0</damage>
-      <descriptor>Negative</descriptor>
+      <descriptor>Essence</descriptor>
       <duration>S</duration>
       <dv>F-1</dv>
       <range>T</range>


### PR DESCRIPTION
Fixing Keywords. A handful of spells in SG have the Negative keyword. At some point, there was a stealth errata which updated them to have the Essence Keyword.


![Screenshot 2023-06-21 at 4 13 20 PM](https://github.com/Teksura/chummer5a/assets/1766631/3e8b30b6-14fd-493b-ac45-e40387938b65)
![Screenshot 2023-06-21 at 4 13 26 PM](https://github.com/Teksura/chummer5a/assets/1766631/e7255a2d-37dd-4c12-990f-70aaf7151263)



